### PR TITLE
print a newline after the result, preventing it from getting attached to any following shell prompt

### DIFF
--- a/bin/haste
+++ b/bin/haste
@@ -25,7 +25,7 @@ def run():
         result = ''
 
     # Return the result to the user
-    sys.stdout.write(result)
+    print(result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Without a following newline, this was causing my terminal to misread the URL as including too much text. Any reason not to add a newline?