### PR TITLE
Fix foreign characters when uploading to hastebin

### DIFF
--- a/hastebin_client/utils.py
+++ b/hastebin_client/utils.py
@@ -6,7 +6,7 @@ from .config import haste_config
 
 def read_data(filename=None):
     if filename:
-        with open(filename, 'r') as f:
+        with open(filename, 'rb') as f:
             return f.read()
 
     # If trying to read from console:

--- a/tests/test_haste_utils.py
+++ b/tests/test_haste_utils.py
@@ -26,8 +26,16 @@ def test_read_data_stdin_abort():
 def test_read_data_file():
     with mock.patch('builtins.open', mock.mock_open(read_data='data')) as mock_open:
         result = read_data('file')
-        mock_open.assert_called_once_with('file', 'r')
+        mock_open.assert_called_once_with('file', 'rb')
     assert result == 'data'
+
+
+def test_read_foreign_data_file():
+    data = '你好café餌ですèêëàâäåôöøùûüîïæпока'
+    with mock.patch('builtins.open', mock.mock_open(read_data=data)) as mock_open:
+        result = read_data('file')
+        mock_open.assert_called_once_with('file', 'rb')
+    assert result == '你好café餌ですèêëàâäåôöøùûüîïæпока'
 
 
 def test_upload():
@@ -56,4 +64,3 @@ def test_upload_too_big():
         post_function.return_value.json.return_value = {'message': 'Document exceeds maximum length.'}
         result = upload('test data')
     assert result is None
-


### PR DESCRIPTION
This PR fixes the output in hastebin when the file contains foreign characters. The program currently works with foreign characters on python2.7 but not on python3, so I suggest this since the readme is explicitly saying that it would work on python 3.x

It also needs a fix for reading from stdin. I don't really have any wise solution but to distinguish when to use `sys.stdin.buffer.read()` (python3) and keep `sys.stdin.read()` (on python2)